### PR TITLE
Update transforms.conf

### DIFF
--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -344,10 +344,10 @@ REGEX = %SPANTREE-.+-PORT_STATE(\s)?: Port (?<src_int>(?<src_int_prefix>\D+)(?<s
 REGEX = %SPANTREE-.+--PORTDEL_SUCCESS(\s)?: (?<src_int>\S+) deleted from (?<src_int_type>\S+) (?<src_vlan>\d+)(\s\(?(?<switch>.+)\))?
 
 [extract_cisco_ios-spantree_topotrap]
-REGEX = %SPANTREE-.+-TOPOTRAP(\s)?: Topology Change Trap for vlan (?<src_vlan>\d+)
+REGEX = %SPANTREE-.+-TOPOTRAP(\s)?: Topology Change Trap for ((vlan (?<src_vlan>\d+))|(instance (?<spanning_tree_instance>\d+)))
 
 [extract_cisco_ios-spantree_rootchange]
-REGEX = %SPANTREE-.+-ROOTCHANGE(\s)?: Root Changed for vlan (?<src_vlan>\d+): New Root Port is (?<src_int>\S+). New Root Mac Address is (?<src_mac>\w+.\w+.\w+)
+REGEX = %SPANTREE-.+-ROOTCHANGE(\s)?: Root Changed for ((vlan (?<src_vlan>\d+))|(instance (?<spanning_tree_instance>\d+))): New Root Port is (?<src_int>\S+). New Root Mac Address is (?<src_mac>\w+.\w+.\w+)
 
 
 ########################


### PR DESCRIPTION
noted that
extract_cisco_ios-spantree_topotrap
extract_cisco_ios-spantree_rootchange

didn't handle MST and provided an update that seems to work
