### PR TITLE
Update props.conf

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -196,6 +196,8 @@ EXTRACT-cisco_ios-eigrp_nbrchange-2 = NBRCHANGE(\s)?:\s(EIGRP-(?<protocol>IPv4|I
 EXTRACT-cisco_ios-bgp_adjchange = ADJCHANGE(\s)?:\sneighbor\s(?<neighbor>\S+)\s(vpn vrf\s(?<vrf>\S+)\s)?(?<state_to>Up|Down)(?<reason>\s.+)?
 # BGP (CRS-3)
 EXTRACT-cisco_ios-BGP-5-ADJCHANGE = ADJCHANGE(\s)?:\sneighbor\s(?<neighbor>\S+)\s(?<state_to>Up|Down)(?:\s\(VRF: (?<vrf>\S+)\)\s)?(?:\(AS: (?<as_number>\d+)\))?(?<reason>\s.+)?
+# BGP (ASR)
+EXTRACT-cisco-ios-BGP-3-IO_INIT = IO_INIT(\s)?:\s+Initialization failed: (?<reason>Failed accepting a replicated session) unable to find\s+nbr\s+(?<neighbor>\S+)
 # MPLS LDP
 EXTRACT-cisco_ios-ldp_nbrchg = NBRCHG(\s)?:\s(?<protocol>TDP|LDP)\sNeighbor\s(?<neighbor>\S+):\d+(\s\((?<unknown_id>\d+)\))?\sis\s(?<state_to>UP|DOWN)(\s\((?<reason>.+)\))?
 # CLNS


### PR DESCRIPTION
added routing dashboard support for the following log

Mar 19 08:24:37 router.local 427823: RP/0/RSP1/CPU0:Mar 19 08:24:37.878 : bgp[1049]: %ROUTING-BGP-3-IO_INIT : Initialization failed: Failed accepting a replicated session unable to find  nbr 10.0.0.10 ()
