### PR TITLE
ospf regex - n7k

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -188,6 +188,7 @@ EXTRACT-cisco_ios-dhcp_snooping_fake_interface = DHCP_SNOOPING_FAKE_INTERFACE(\s
 # Routing
 # OSPF
 EXTRACT-cisco_ios-adjchg = ADJCHG(\s)?:\sProcess\s(?<process_id>\d+),\sNbr\s(?<neighbor>\S+)\son\s(?<src_int>\S+)\sfrom\s(?<state_from>DOWN|INIT|2WAY|EXSTART|EXCHANGE|LOADING|FULL)\sto\s(?<state_to>DOWN|INIT|2WAY|EXSTART|EXCHANGE|LOADING|FULL),\s(?<reason>.+)
+EXTRACT-cisco_nxos-nbrstate = %OSPF-5-NBRSTATE:  ospf\S+\s+\[\d+\]\s+Process\s+(?<process_id>\d+), Nbr (?<neighbor>\S+) on Vlan(?<vlan>\d+) from (?<state_from>\S+) to (?<state_to>[^,]+), (?<reason>\S+)
 # EIGRP
 EXTRACT-cisco_ios-eigrp_nbrchange = NBRCHANGE(\s)?:\s(?<protocol>IP|IPv6)-EIGRP\((?<process_id>\d+)\)\s(?<as_number>\d+):\sNeighbor\s(?<neighbor>\S+)\s\((?<src_int>\S+)\)\sis\s(?<state_to>up|down):(?<reason>.+)
 # EIGRP for IOS 15.0

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -360,9 +360,6 @@ REGEX = %LDP-.+-SP(\s)?: (?<neighbor>\S+):\d+: (?<result>.+)
 [extract_cisco_ios-OSPF-4-ERRRCV]
 REGEX = %OSPF-.+-ERRRCV(\s)?: Received invalid packet: (?<reason>.+) from (?<neighbor>\S+), (?<src_int>\S+) 
 
-[extract_cisco_ios-OSPF-5-NBRSTATE]
-REGEX = %OSPF-5-NBRSTATE:  ospf\S+\s+\[\d+\]\s+Process\s+(?<process_id>\d+), Nbr (?<neighbor>\S+) on Vlan(?<vlan>\d+) from (?<state_from>\S+) to (?<state_to>[^,]+), (?<reason>\S+)
-
 
 ########################
 # Configuration

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -360,6 +360,9 @@ REGEX = %LDP-.+-SP(\s)?: (?<neighbor>\S+):\d+: (?<result>.+)
 [extract_cisco_ios-OSPF-4-ERRRCV]
 REGEX = %OSPF-.+-ERRRCV(\s)?: Received invalid packet: (?<reason>.+) from (?<neighbor>\S+), (?<src_int>\S+) 
 
+[extract_cisco_ios-OSPF-5-NBRSTATE]
+REGEX = %OSPF-5-NBRSTATE:  ospf\S+\s+\[\d+\]\s+Process\s+(?<process_id>\d+), Nbr (?<neighbor>\S+) on Vlan(?<vlan>\d+) from (?<state_from>\S+) to (?<state_to>[^,]+), (?<reason>\S+)
+
 
 ########################
 # Configuration


### PR DESCRIPTION
added regex to handle the following from a nexus 7k

%OSPF-5-NBRSTATE:  ospf-11 [7674]  Process 11, Nbr 1.1.1.1 on Vlan50 from EXCHANGE to FULL, EXCHDONE
%OSPF-5-NBRSTATE:  ospf-11 [7708]  Process 11, Nbr 1.1.1.1 on Vlan50 from EXSTART to EXCHANGE, NEGDONE
