### PR TITLE
Update transforms.conf

### DIFF
--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -16,14 +16,14 @@
 #
 [force_sourcetype_for_cisco_ios]
 DEST_KEY = MetaData:Sourcetype
-REGEX = (?<reported_hostname>\S+)?(\s(?<event_id>\d+)?\:\s(?:.\S+\:\s)?(?<reliable_time>[\.\*])?(?<device_time>.+)?)?\:\s+(?:%|#)(?<facility>(?!POLICY_ENGINE|UCSM|FWSM|ASA|PIX|ACE)[A-Z0-9_]+)-((?<subfacility>[A-Z012_]*(-?[A-Z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+):\s(?<message_text>.+)
+REGEX = ((?<reported_hostname>\S+)\s)?((?<event_id>\d+)?\:\s(?:.\S+\:\s)?(?<reliable_time>[\.\*])?(?<device_time>.+)?)?\:\s+(?:%|#)(?<facility>(?!POLICY_ENGINE|UCSM|FWSM|ASA|PIX|ACE)[A-Z0-9_]+)-((?<subfacility>[A-Z012_]*(-?[A-Z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+):\s(?<message_text>.+)
 FORMAT = sourcetype::cisco:ios
 
 # Match 1: Oct 9 09:59:46 10.117.0.147 85915: za-mid-mtb-msr01 RP/0/RSP0/CPU0:Oct 9 09:59:46.271 : exec[65908]: %SECURITY-login-6-AUTHEN_SUCCESS : Successfully authenticated user 'argus' from '10.117.1.18' on 'vty3'
 # Match 2: Mar 5 18:00:20 1.1.1.1 85915: LC/0/2/CPU0:Aug 15 21:39:11.325 2008: ifmgr[163]: %PKT_INFRA-LINEPROTO-5-UPDOWN : Line protocol on Interface POS0/2/0/2, changed state to Down
 [force_sourcetype_for_cisco_ios-xr]
 DEST_KEY = MetaData:Sourcetype
-REGEX = (?<reported_hostname>\S+)?\s(?<event_id>\d+)\:\s((?<reported_hostname2>\S+)\s)?(?<node_id>(?:[A-Z]+)\/(?:\d+)\/(?:[A-Z0-9]+)\/(?:[A-Z0-9]+))\:(?<device_time>.+)\s?\:\s?(?<process_name>[A-Za-z0-9_]+)\[(?<pid>\d+)\]\:\s+%(?<category>[A-Za-z0-9_]+)-(?<facility>[A-Za-z0-9_]+)-((?<subfacility>[A-Za-z12_]*(-?[A-Za-z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+)\s:\s(?<message_text>.+)
+REGEX = ((?<reported_hostname>\S+)\s)?(?<event_id>\d+)\:\s((?<reported_hostname2>\S+)\s)?(?<node_id>(?:[A-Z]+)\/(?:\d+)\/(?:[A-Z0-9]+)\/(?:[A-Z0-9]+))\:(?<device_time>.+)\s?\:\s?(?<process_name>[A-Za-z0-9_]+)\[(?<pid>\d+)\]\:\s+%(?<category>[A-Za-z0-9_]+)-(?<facility>[A-Za-z0-9_]+)-((?<subfacility>[A-Za-z12_]*(-?[A-Za-z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+)\s:\s(?<message_text>.+)
 FORMAT = sourcetype::cisco:ios
 
 [force_sourcetype_for_cisco_ios-xe]
@@ -49,12 +49,12 @@ FORMAT = sourcetype::cisco:ios
 
 [force_index_for_cisco_ios]
 DEST_KEY = _MetaData:Index
-REGEX = (?<reported_hostname>\S+)?(\s(?<event_id>\d+)?\:\s(?:.\S+\:\s)?(?<reliable_time>[\.\*])?(?<device_time>.+)?)?\:\s+(?:%|#)(?<facility>(?!POLICY_ENGINE|UCSM|FWSM|ASA|PIX|ACE)[A-Z0-9_]+)-(?<subfacility>[A-Z12_]*(-?[A-Z_]*))-?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+):\s(?<message_text>.+)
+REGEX = ((?<reported_hostname>\S+)\s)?((?<event_id>\d+)?\:\s(?:.\S+\:\s)?(?<reliable_time>[\.\*])?(?<device_time>.+)?)?\:\s+(?:%|#)(?<facility>(?!POLICY_ENGINE|UCSM|FWSM|ASA|PIX|ACE)[A-Z0-9_]+)-(?<subfacility>[A-Z12_]*(-?[A-Z_]*))-?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+):\s(?<message_text>.+)
 FORMAT = ios
 
 [force_index_for_cisco_ios-xr]
 DEST_KEY = _MetaData:Index
-REGEX = (?<reported_hostname>\S+)?\s(?<event_id>\d+)\:\s((?<reported_hostname2>\S+)\s)?(?<node_id>(?:[A-Z]+)\/(?:\d+)\/(?:[A-Z0-9]+)\/(?:[A-Z0-9]+))\:(?<device_time>.+)\s?\:\s?(?<process_name>[A-Za-z0-9_]+)\[(?<pid>\d+)\]\:\s+%(?<category>[A-Za-z0-9_]+)-(?<facility>[A-Za-z0-9_]+)-((?<subfacility>[A-Za-z12_]*(-?[A-Za-z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+)\s:\s(?<message_text>.+)
+REGEX = ((?<reported_hostname>\S+)\s)?(?<event_id>\d+)\:\s((?<reported_hostname2>\S+)\s)?(?<node_id>(?:[A-Z]+)\/(?:\d+)\/(?:[A-Z0-9]+)\/(?:[A-Z0-9]+))\:(?<device_time>.+)\s?\:\s?(?<process_name>[A-Za-z0-9_]+)\[(?<pid>\d+)\]\:\s+%(?<category>[A-Za-z0-9_]+)-(?<facility>[A-Za-z0-9_]+)-((?<subfacility>[A-Za-z12_]*(-?[A-Za-z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+)\s:\s(?<message_text>.+)
 FORMAT = ios
 
 # Cisco:IOS:Configuration
@@ -97,8 +97,8 @@ case_sensitive_match = true
 [extract_cisco_ios-general]
 # ap_mac for Access Points logging directly. Tested with:
 # May 7 10:10:10 10.10.0.154 61: AP:7cad.7428.3ddb: *May 7 17:10:10.731: %LINK-6-UPDOWN: Interface Dot11Radio1, changed state to down
-REGEX = (?<reported_hostname>\S+)?(\s(?<event_id>\d+)?\:\s(AP:(?<direct_ap_mac>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}):\s)?(?:.\S+\:\s)?(?<reliable_time>[\.\*])?(?<device_time>.+)?)?\:\s+(?:%|#)(?<facility>(?!POLICY_ENGINE|UCSM|FWSM|ASA|PIX|ACE)[A-Z0-9_]+)-((?<subfacility>[A-Z012_]*(-?[A-Z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+):\s(?<message_text>.+)
-#REGEX = (?<reported_hostname>\S+)?(\s(?<event_id>\d+)?\:\s(?:.\S+\:\s)?(?<reliable_time>[\.\*])?(?<device_time>.+)?)?\:\s+(?:%|#)(?<facility>(?!POLICY_ENGINE|UCSM|FWSM|ASA|PIX|ACE)[A-Z0-9_]+)-((?<subfacility>[A-Z012_]*(-?[A-Z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+):\s(?<message_text>.+)
+REGEX = ((?<reported_hostname>\S+)\s)?((?<event_id>\d+)?\:\s(AP:(?<direct_ap_mac>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}):\s)?(?:.\S+\:\s)?(?<reliable_time>[\.\*])?(?<device_time>.+)?)?\:\s+(?:%|#)(?<facility>(?!POLICY_ENGINE|UCSM|FWSM|ASA|PIX|ACE)[A-Z0-9_]+)-((?<subfacility>[A-Z012_]*(-?[A-Z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+):\s(?<message_text>.+)
+#REGEX = ((?<reported_hostname>\S+)\s)?((?<event_id>\d+)?\:\s(?:.\S+\:\s)?(?<reliable_time>[\.\*])?(?<device_time>.+)?)?\:\s+(?:%|#)(?<facility>(?!POLICY_ENGINE|UCSM|FWSM|ASA|PIX|ACE)[A-Z0-9_]+)-((?<subfacility>[A-Z012_]*(-?[A-Z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+):\s(?<message_text>.+)
 
 # VERY experimental for RFC5424 support
 [extract_cisco_ios-general-rfc5424]
@@ -106,7 +106,7 @@ REGEX = (?<RFC5424_PRI>\<(?<RFC5424_PRIVAL>\d+)\>)(?<RFC5424_TIME>\d+) (?<rfc338
 
 # Cisco IOS XR
 [extract_cisco_ios-general-xr]
-REGEX = (?<reported_hostname>\S+)?\s(?<event_id>\d+)\:\s((?<reported_hostname2>\S+)\s)?(?<node_id>(?:[A-Z]+)\/(?:\d+)\/(?:[A-Z0-9]+)\/(?:[A-Z0-9]+))\:(?<device_time>.+)\s?\:\s?(?<process_name>[A-Za-z0-9_]+)\[(?<pid>\d+)\]\:\s+%(?<category>[A-Za-z0-9_]+)-(?<facility>[A-Za-z0-9_]+)-((?<subfacility>[A-Za-z12_]*(-?[A-Za-z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+)\s:\s(?<message_text>.+)
+REGEX = ((?<reported_hostname>\S+)\s)?(?<event_id>\d+)\:\s((?<reported_hostname2>\S+)\s)?(?<node_id>(?:[A-Z]+)\/(?:\d+)\/(?:[A-Z0-9]+)\/(?:[A-Z0-9]+))\:(?<device_time>.+)\s?\:\s?(?<process_name>[A-Za-z0-9_]+)\[(?<pid>\d+)\]\:\s+%(?<category>[A-Za-z0-9_]+)-(?<facility>[A-Za-z0-9_]+)-((?<subfacility>[A-Za-z12_]*(-?[A-Za-z_][^-]*))-?)?(?<severity_id>[0-7])-(?<mnemonic>[A-Z0-9_]+)\s:\s(?<message_text>.+)
 
 [extract_cisco_ios-general-wlc]
 REGEX = ^(?<filename>\S+):(?<filename_line>\d+)


### PR DESCRIPTION
Transform corrected in case of missing reported_hostname. General field extraction also edited.

The previous configuration enforced that the log start with a space character, which does not allow log to be extracted properly if the reported_hostname is actually missing.
