### PR TITLE
Update props.conf

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -59,6 +59,7 @@ FIELDALIAS-sch_fields-99 = serial_number AS serial, software_version AS version,
 
 [cisco:ios]
 KV_MODE = none
+TIME_PREFIX=(\S*:\s*)*
 REPORT-cisco_ios-general = extract_cisco_ios-general, extract_cisco_ios-general-xr, extract_cisco_ios-general-wlc, extract_cisco_ios-general-rfc5424
 
 LOOKUP-cisco_ios-severity = cisco_ios_severity severity_id OUTPUT severity,severity_name,severity_id_and_name,severity_description


### PR DESCRIPTION
Timestamp is not properly parsed out if there is no space between the event_id and node_id.

For example, the following syslog line timestamp is not currently parsed correctly

123: RP/0/RSP0/CPU0:Jan 12 12:34:56.123 : pim[1234]: %ROUTING-IPV4_PIM-5-NBRCHG  message_text
